### PR TITLE
Next - Prevent adding non-compliant templates

### DIFF
--- a/contracts/shared/interfaces/ITemplate.sol
+++ b/contracts/shared/interfaces/ITemplate.sol
@@ -2,5 +2,7 @@
 pragma solidity >=0.6.8;
 
 interface ITemplate {
+    function templateName() external;
+
     function init(bytes calldata data) external;
 }

--- a/contracts/templates/TemplateLauncher.sol
+++ b/contracts/templates/TemplateLauncher.sol
@@ -121,6 +121,10 @@ contract TemplateLauncher is CloneFactory {
         returns (uint256)
     {
         require(
+            address(_template) != address(0),
+            "TemplateLauncher: ZERO_ADDRESS"
+        );
+        require(
             msg.value >= IAquaFactory(factory).templateFee(),
             "TemplateLauncher: TEMPLATE_FEE_NOT_PROVIDED"
         );

--- a/contracts/templates/TemplateLauncher.sol
+++ b/contracts/templates/TemplateLauncher.sol
@@ -132,6 +132,10 @@ contract TemplateLauncher is CloneFactory {
             templateToId[_template] == 0,
             "TemplateLauncher: TEMPLATE_DUPLICATE"
         );
+        require(
+            isTemplateCompliant(_template),
+            "TemplateLauncher: TEMPLATE_NOT_COMPLIANT"
+        );
 
         uint256 templateId = templateCounter;
         templateCounter++;
@@ -184,5 +188,17 @@ contract TemplateLauncher is CloneFactory {
 
     function getTemplateId(address _template) public view returns (uint256) {
         return templateToId[_template];
+    }
+
+    /// @dev verifies that a template address implements the AquaTemplate standard
+    /// @param _template the template contract address
+    function isTemplateCompliant(address _template) private returns (bool) {
+        try ITemplate(_template).templateName() {
+            return true;
+        } catch (
+            bytes memory /*lowLevelData*/
+        ) {
+            return false;
+        }
     }
 }

--- a/test/contract/TemplateLauncher.spec.ts
+++ b/test/contract/TemplateLauncher.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { BigNumber } from "ethers";
+import { BigNumber, constants } from "ethers";
 import hre, { ethers, waffle } from "hardhat";
 
 import { expandTo18Decimals } from "./utilities";
@@ -183,6 +183,18 @@ describe("TemplateLauncher", async () => {
                     .connect(user_2)
                     .addTemplate(fixedPriceSaleTemplateDefault.address)
             ).to.be.revertedWith("TemplateLauncher: FORBIDDEN");
+        });
+
+        it("throws if template address is zero", async () => {
+            await expect(
+                templateLauncher.addTemplate(constants.AddressZero) // Adding a sale module is good test case
+            ).to.be.revertedWith("TemplateLauncher: ZERO_ADDRESS");
+        });
+
+        it("throws if template contract is not implementing templateName method", async () => {
+            await expect(
+                templateLauncher.addTemplate(fixedPriceSale.address) // Adding a sale module is good test case
+            ).to.be.revertedWith("TemplateLauncher: TEMPLATE_NOT_COMPLIANT");
         });
 
         it("throws if template is added twice", async () => {


### PR DESCRIPTION
### Summary 

Adds checks to prevent adding non-compliant templates to Aqua's TemplateLauncher.

## Description

<!--- Provide a general summary of your changes in the Title above -->

`TemplateLauncher.addTemplate` does not do contract integrity checks:

1. Template contract has to implement a name - `templateName`.
2. Template contract has to implement a initialization method `init`.

Skipping number 2 is ok because further a launched template without `init` method is impossible. However, `templateName` is required for keeping track of all templates in Aqua template repository. Further `templateName` is required by the subgraph, [which breaks if the contract does not implement correct methods](https://github.com/cryptonative-ch/aqua-subgraph/issues/92).

- Closes #120

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.