### PR TITLE
Next fix fair sale owner

### DIFF
--- a/contracts/sales/FairSale.sol
+++ b/contracts/sales/FairSale.sol
@@ -25,8 +25,8 @@ contract FairSale {
         _;
     }
 
-    modifier onlyDeployer() {
-        require(msg.sender == deployer, "FixedPriceSale: FORBIDDEN");
+    modifier onlyOwner() {
+        require(msg.sender == owner, "FairSale: FORBIDDEN");
         _;
     }
 
@@ -102,7 +102,7 @@ contract FairSale {
     event UserRegistration(address indexed user, uint64 userId);
 
     string public constant TEMPLATE_NAME = "FairSale";
-    address private deployer;
+    address public owner;
     IERC20 public tokenOut;
     IERC20 public tokenIn;
     uint256 public orderCancellationEndDate;
@@ -123,10 +123,6 @@ contract FairSale {
     IdToAddressBiMap.Data private registeredUsers;
     uint64 public numUsers;
 
-    constructor() public {
-        deployer = msg.sender;
-    }
-
     // @dev: function to intiate a new auction
     // Warning: In case the auction is expected to raise more than
     // 2^96 units of the tokenIn, don't start the auction, as
@@ -145,7 +141,8 @@ contract FairSale {
         uint96 _minBuyAmount,
         uint256 _minimumBiddingAmountPerOrder,
         uint256 _minFundingThreshold,
-        bool _isAtomicClosureAllowed
+        bool _isAtomicClosureAllowed,
+        address _owner
     ) internal {
         // withdraws sellAmount
         initialized = true;
@@ -182,7 +179,7 @@ contract FairSale {
         );
         sellOrders.initializeEmptyList();
         uint64 userId = getUserId(msg.sender);
-
+        owner = _owner;
         tokenOut = _tokenOut;
         tokenIn = _tokenIn;
         orderCancellationEndDate = _orderCancellationEndDate;
@@ -555,7 +552,7 @@ contract FairSale {
         sendOutTokens(sumTokenOutAmount, sumTokenInAmount, userId); //[3]
     }
 
-    function init(bytes calldata _data) public notInitialized onlyDeployer {
+    function init(bytes calldata _data) public notInitialized {
         (
             IERC20 _tokenIn,
             IERC20 _tokenOut,
@@ -566,7 +563,8 @@ contract FairSale {
             uint96 _minBidAmountToReceive,
             uint256 _minimumBiddingAmountPerOrder,
             uint256 _minSellThreshold,
-            bool _isAtomicClosureAllowed
+            bool _isAtomicClosureAllowed,
+            address _owner
         ) = abi.decode(
                 _data,
                 (
@@ -579,7 +577,8 @@ contract FairSale {
                     uint96,
                     uint256,
                     uint256,
-                    bool
+                    bool,
+                    address
                 )
             );
 
@@ -593,7 +592,8 @@ contract FairSale {
             _minBidAmountToReceive,
             _minimumBiddingAmountPerOrder,
             _minSellThreshold,
-            _isAtomicClosureAllowed
+            _isAtomicClosureAllowed,
+            _owner
         );
     }
 

--- a/contracts/templates/FairSaleTemplate.sol
+++ b/contracts/templates/FairSaleTemplate.sol
@@ -19,7 +19,8 @@ contract FairSaleTemplate is AquaTemplate {
     event TemplateInitialized(
         address tokenIn,
         address tokenOut,
-        uint256 duration,
+        uint256 auctionStartDate,
+        uint256 auctionEndDate,
         uint256 tokensForSale,
         uint96 minPrice,
         uint96 minBuyAmount,
@@ -39,7 +40,8 @@ contract FairSaleTemplate is AquaTemplate {
     /// @param _saleTemplateId Aqua Auction TemplateId
     /// @param _tokenIn token to bid on auction
     /// @param _tokenOut token to be auctioned
-    /// @param _duration auction duration in seconds
+    /// @param _auctionStartDate unix timestamp when the auction starts
+    /// @param _auctionEndDate unix timestamp when the auction ends
     /// @param _tokensForSale amount of tokens to be auctioned
     /// @param _minPrice minimum Price that token should be auctioned for
     /// @param _minBuyAmount minimum amount of tokens an investor has to buy
@@ -50,7 +52,8 @@ contract FairSaleTemplate is AquaTemplate {
         uint256 _saleTemplateId,
         address _tokenIn,
         address _tokenOut,
-        uint256 _duration,
+        uint256 _auctionStartDate,
+        uint256 _auctionEndDate,
         uint256 _tokensForSale,
         uint96 _minPrice,
         uint96 _minBuyAmount,
@@ -76,7 +79,8 @@ contract FairSaleTemplate is AquaTemplate {
             IERC20(_tokenIn),
             IERC20(_tokenOut),
             _orderCancelationPeriodDuration,
-            _duration,
+            _auctionStartDate,
+            _auctionEndDate,
             uint96(_tokensForSale),
             _minBuyAmount,
             _minimumBiddingAmountPerOrder,
@@ -87,7 +91,8 @@ contract FairSaleTemplate is AquaTemplate {
         emit TemplateInitialized(
             _tokenIn,
             _tokenOut,
-            _duration,
+            _auctionStartDate,
+            _auctionEndDate,
             _tokensForSale,
             _minPrice,
             _minBuyAmount,
@@ -119,7 +124,8 @@ contract FairSaleTemplate is AquaTemplate {
             uint256 _saleTemplateId,
             address _tokenIn,
             address _tokenOut,
-            uint256 _duration,
+            uint256 _auctionStartDate,
+            uint256 _auctionEndDate,
             uint256 _tokensForSale,
             uint96 _minPrice,
             uint96 _minBuyAmount,
@@ -134,6 +140,7 @@ contract FairSaleTemplate is AquaTemplate {
                     uint256,
                     address,
                     address,
+                    uint256,
                     uint256,
                     uint256,
                     uint96,
@@ -151,7 +158,8 @@ contract FairSaleTemplate is AquaTemplate {
                 _saleTemplateId,
                 _tokenIn,
                 _tokenOut,
-                _duration,
+                _auctionStartDate,
+                _auctionEndDate,
                 _tokensForSale,
                 _minPrice,
                 _minBuyAmount,

--- a/contracts/templates/FairSaleTemplate.sol
+++ b/contracts/templates/FairSaleTemplate.sol
@@ -85,7 +85,8 @@ contract FairSaleTemplate is AquaTemplate {
             _minBuyAmount,
             _minimumBiddingAmountPerOrder,
             _minRaise,
-            isAtomicClosureAllowed
+            isAtomicClosureAllowed,
+            tokenSupplier
         );
 
         emit TemplateInitialized(

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,8 +38,8 @@ export const config: HardhatUserConfig = {
             accounts: [`${process.env.PRIVATE_KEY}`],
         },
         hardhat: {
-            hardfork: process.env.CODE_COVERAGE ? "berlin" : "london"
-        }
+            hardfork: process.env.CODE_COVERAGE ? "berlin" : "london",
+        },
     },
     mocha: {
         timeout: "600s",

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -11,6 +11,7 @@ export interface InitiateAuctionInput {
     minimumBiddingAmountPerOrder: BigNumberish;
     minFundingThreshold: BigNumberish;
     isAtomicClosureAllowed: boolean;
+    owner: string;
 }
 
 export const contractConstructorArgs = <T extends ContractFactory>(

--- a/test/contract/FairSaleTemplate.spec.ts
+++ b/test/contract/FairSaleTemplate.spec.ts
@@ -206,5 +206,8 @@ describe("FairSaleTemplate", async () => {
         await expect(
             fairSaleTemplate.connect(user_2).createSale()
         ).to.be.revertedWith("FairSaleTemplate: FORBIDDEN");
+
+        await tokenB.approve(saleLauncher.address, expandTo18Decimals(3000));
+        await expect(fairSaleTemplate.createSale()).not.to.be.reverted;
     });
 });

--- a/test/contract/FairSaleTemplate.spec.ts
+++ b/test/contract/FairSaleTemplate.spec.ts
@@ -38,14 +38,15 @@ describe("FairSaleTemplate", async () => {
 
     let defaultOrderCancelationPeriodDuration: number;
     let defaultStartDate: number;
-    let defaultDuration: number;
+    let defaultEndDate: number;
 
     function encodeInitDataFairSale(
         saleLauncher: string,
         saleTemplateId: number,
         tokenIn: string,
         tokenOut: string,
-        duration: number,
+        auctionStartDate: number,
+        auctionEndDate: number,
         tokensForSale: BigNumber,
         minPrice: BigNumber,
         minBuyAmount: BigNumber,
@@ -62,6 +63,7 @@ describe("FairSaleTemplate", async () => {
                 "address",
                 "uint256",
                 "uint256",
+                "uint256",
                 "uint96",
                 "uint96",
                 "uint256",
@@ -74,7 +76,8 @@ describe("FairSaleTemplate", async () => {
                 saleTemplateId,
                 tokenIn,
                 tokenOut,
-                duration,
+                auctionStartDate,
+                auctionEndDate,
                 tokensForSale,
                 minPrice,
                 minBuyAmount,
@@ -90,7 +93,7 @@ describe("FairSaleTemplate", async () => {
         currentBlockNumber = await ethers.provider.getBlockNumber();
         currentBlock = await ethers.provider.getBlock(currentBlockNumber);
         defaultStartDate = currentBlock.timestamp + 500;
-        defaultDuration = defaultStartDate + 86400;
+        defaultEndDate = defaultStartDate + 86400;
         defaultOrderCancelationPeriodDuration = currentBlock.timestamp + 3600;
 
         aquaFactory = await new AquaFactory__factory(templateManager).deploy(
@@ -137,7 +140,8 @@ describe("FairSaleTemplate", async () => {
             1,
             tokenA.address,
             tokenB.address,
-            defaultDuration,
+            defaultStartDate,
+            defaultEndDate,
             defaultTokensForSale,
             defaultMinPrice,
             defaultMinBuyAmount,
@@ -152,7 +156,8 @@ describe("FairSaleTemplate", async () => {
             .withArgs(
                 tokenA.address,
                 tokenB.address,
-                defaultDuration,
+                defaultStartDate,
+                defaultEndDate,
                 defaultTokensForSale,
                 defaultMinPrice,
                 defaultMinBuyAmount,
@@ -172,7 +177,8 @@ describe("FairSaleTemplate", async () => {
             1,
             tokenA.address,
             tokenB.address,
-            defaultDuration,
+            defaultStartDate,
+            defaultEndDate,
             defaultTokensForSale,
             defaultMinPrice,
             defaultMinBuyAmount,
@@ -187,7 +193,8 @@ describe("FairSaleTemplate", async () => {
             .withArgs(
                 tokenA.address,
                 tokenB.address,
-                defaultDuration,
+                defaultStartDate,
+                defaultEndDate,
                 defaultTokensForSale,
                 defaultMinPrice,
                 defaultMinBuyAmount,

--- a/test/contract/SaleLauncher.spec.ts
+++ b/test/contract/SaleLauncher.spec.ts
@@ -34,27 +34,30 @@ describe("SaleLauncher", async () => {
     let tokenB: ERC20Mintable;
     let currentBlockNumber, currentBlock;
 
-    const defaultTokenPrice = expandTo18Decimals(10);
     const defaultTokensForSale = expandTo18Decimals(2000);
-    const defaultMinCommitment = expandTo18Decimals(2);
-    const defaultMaxCommitment = expandTo18Decimals(10);
     const defaultMinRaise = expandTo18Decimals(5000);
+    const defaultMinPrice = expandTo18Decimals(1);
+    const defaultMinBuyAmount = expandTo18Decimals(1);
+    const defaultMinimumBiddingAmountPerOrder = expandTo18Decimals(10);
+
+    let defaultOrderCancelationPeriodDuration: number;
     let defaultStartDate: number;
     let defaultEndDate: number;
 
-    function encodeInitDataFixedPrice(
+    function encodeInitDataFairSale(
         saleLauncher: string,
         saleTemplateId: number,
         tokenIn: string,
         tokenOut: string,
-        tokenPrice: BigNumber,
+        auctionStartDate: number,
+        auctionEndDate: number,
         tokensForSale: BigNumber,
-        startDate: number,
-        endDate: number,
-        minCommitment: BigNumber,
-        maxCommitment: BigNumber,
+        minPrice: BigNumber,
+        minBuyAmount: BigNumber,
         minRaise: BigNumber,
-        owner: string
+        orderCancelationPeriodDuration: number,
+        minimumBiddingAmountPerOrder: BigNumber,
+        tokenSupplier: string
     ) {
         return ethers.utils.defaultAbiCoder.encode(
             [
@@ -65,7 +68,8 @@ describe("SaleLauncher", async () => {
                 "uint256",
                 "uint256",
                 "uint256",
-                "uint256",
+                "uint96",
+                "uint96",
                 "uint256",
                 "uint256",
                 "uint256",
@@ -76,14 +80,15 @@ describe("SaleLauncher", async () => {
                 saleTemplateId,
                 tokenIn,
                 tokenOut,
-                tokenPrice,
+                auctionStartDate,
+                auctionEndDate,
                 tokensForSale,
-                startDate,
-                endDate,
-                minCommitment,
-                maxCommitment,
+                minPrice,
+                minBuyAmount,
                 minRaise,
-                owner,
+                orderCancelationPeriodDuration,
+                minimumBiddingAmountPerOrder,
+                tokenSupplier,
             ]
         );
     }
@@ -91,9 +96,9 @@ describe("SaleLauncher", async () => {
     beforeEach(async () => {
         currentBlockNumber = await ethers.provider.getBlockNumber();
         currentBlock = await ethers.provider.getBlock(currentBlockNumber);
-
         defaultStartDate = currentBlock.timestamp + 500;
-        defaultEndDate = defaultStartDate + 86400; // 24 hours
+        defaultEndDate = defaultStartDate + 86400;
+        defaultOrderCancelationPeriodDuration = currentBlock.timestamp + 3600;
 
         const AquaFactory =
             await ethers.getContractFactory<AquaFactory__factory>(
@@ -218,18 +223,19 @@ describe("SaleLauncher", async () => {
 
     describe("launching sales", async () => {
         it("throws if trying to launch invalid templateId", async () => {
-            const initData = encodeInitDataFixedPrice(
+            const initData = encodeInitDataFairSale(
                 saleLauncher.address,
                 1,
                 tokenA.address,
                 tokenB.address,
-                defaultTokenPrice,
-                defaultTokensForSale,
                 defaultStartDate,
                 defaultEndDate,
-                defaultMinCommitment,
-                defaultMaxCommitment,
+                defaultTokensForSale,
+                defaultMinPrice,
+                defaultMinBuyAmount,
                 defaultMinRaise,
+                defaultOrderCancelationPeriodDuration,
+                defaultMinimumBiddingAmountPerOrder,
                 templateManager.address
             );
 
@@ -247,18 +253,19 @@ describe("SaleLauncher", async () => {
         it("throws if trying to launch sales without providing sales fee", async () => {
             await aquaFactory.setSaleFee(500);
 
-            const initData = encodeInitDataFixedPrice(
+            const initData = encodeInitDataFairSale(
                 saleLauncher.address,
                 1,
                 tokenA.address,
                 tokenB.address,
-                defaultTokenPrice,
-                defaultTokensForSale,
                 defaultStartDate,
                 defaultEndDate,
-                defaultMinCommitment,
-                defaultMaxCommitment,
+                defaultTokensForSale,
+                defaultMinPrice,
+                defaultMinBuyAmount,
                 defaultMinRaise,
+                defaultOrderCancelationPeriodDuration,
+                defaultMinimumBiddingAmountPerOrder,
                 templateManager.address
             );
 
@@ -278,18 +285,19 @@ describe("SaleLauncher", async () => {
 
             expect(await saleLauncher.numberOfSales()).to.be.equal(0);
 
-            const initData = encodeInitDataFixedPrice(
+            const initData = encodeInitDataFairSale(
                 saleLauncher.address,
                 1,
                 tokenA.address,
                 tokenB.address,
-                defaultTokenPrice,
-                defaultTokensForSale,
                 defaultStartDate,
                 defaultEndDate,
-                defaultMinCommitment,
-                defaultMaxCommitment,
+                defaultTokensForSale,
+                defaultMinPrice,
+                defaultMinBuyAmount,
                 defaultMinRaise,
+                defaultOrderCancelationPeriodDuration,
+                defaultMinimumBiddingAmountPerOrder,
                 templateManager.address
             );
 

--- a/test/contract/defaultContractInteractions.ts
+++ b/test/contract/defaultContractInteractions.ts
@@ -5,7 +5,7 @@ import { encodeFairSaleInitData } from "./utilities";
 import { InitiateAuctionInput } from "../../src/ts/types";
 
 type PartialAuctionInput = Partial<InitiateAuctionInput> &
-    Pick<InitiateAuctionInput, "tokenOut" | "tokenIn">;
+    Pick<InitiateAuctionInput, "tokenOut" | "tokenIn" | "owner">;
 
 async function createAuctionInputWithDefaults(
     parameters: PartialAuctionInput
@@ -22,14 +22,25 @@ async function createAuctionInputWithDefaults(
         parameters.minimumBiddingAmountPerOrder ?? 1,
         parameters.minFundingThreshold ?? 0,
         parameters.isAtomicClosureAllowed ?? false,
+        parameters.owner,
     ];
 }
 
 export async function createAuctionWithDefaults(
     fairSale: FairSale,
-    parameters: PartialAuctionInput
+    parameters: Partial<InitiateAuctionInput> &
+        Pick<InitiateAuctionInput, "tokenOut" | "tokenIn">
 ) {
-    const defaultValues = await createAuctionInputWithDefaults(parameters);
+    if (
+        !parameters.owner ||
+        parameters.owner === ethers.constants.AddressZero
+    ) {
+        const owner = await fairSale.signer.getAddress();
+        parameters.owner = owner;
+    }
+    const defaultValues = await createAuctionInputWithDefaults(
+        parameters as PartialAuctionInput
+    );
     const params = encodeFairSaleInitData(...defaultValues);
 
     return fairSale.init(params);

--- a/test/contract/utilities.ts
+++ b/test/contract/utilities.ts
@@ -59,7 +59,8 @@ export const encodeFairSaleInitData = (
     minBidAmountToReceive: BigNumberish,
     minimumBiddingAmountPerOrder: BigNumberish,
     minSellThreshold: BigNumberish,
-    isAtomicClosureAllowed: boolean
+    isAtomicClosureAllowed: boolean,
+    owner: string
 ) => {
     return ethers.utils.defaultAbiCoder.encode(
         [
@@ -73,6 +74,7 @@ export const encodeFairSaleInitData = (
             "uint256",
             "uint256",
             "bool",
+            "address",
         ],
         [
             tokenIn,
@@ -85,6 +87,7 @@ export const encodeFairSaleInitData = (
             minimumBiddingAmountPerOrder,
             minSellThreshold,
             isAtomicClosureAllowed,
+            owner,
         ]
     );
 };


### PR DESCRIPTION
## Description

Owner of `FairSale` is now set in `init` instead of `constructor`.

## Motivation and Context

Currently `FairSale` sets owner of the contract in the `constructor` call which is always `0x0` when contract is cloned by `SaleLauncher`. Then, `init` could be initiated only by owner, so in practice `FairSale` could be never created.

List of changes:
- `onlyDeployer` => `onlyOwner` to be consistent wtih `FixedPriceSale`,
- `onlyOwner` modifier has been removed from `init`
- owner is now set in `init`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.