### PR TITLE
fix owner in FairSale

### DIFF
--- a/contracts/sales/FairSale.sol
+++ b/contracts/sales/FairSale.sol
@@ -25,8 +25,8 @@ contract FairSale {
         _;
     }
 
-    modifier onlyDeployer() {
-        require(msg.sender == deployer, "FixedPriceSale: FORBIDDEN");
+    modifier onlyOwner() {
+        require(msg.sender == owner, "FairSale: FORBIDDEN");
         _;
     }
 
@@ -99,7 +99,7 @@ contract FairSale {
     event UserRegistration(address indexed user, uint64 userId);
 
     string public constant TEMPLATE_NAME = "FairSale";
-    address private deployer;
+    address public owner;
     IERC20 public tokenOut;
     IERC20 public tokenIn;
     uint256 public orderCancellationEndDate;
@@ -119,10 +119,6 @@ contract FairSale {
     IdToAddressBiMap.Data private registeredUsers;
     uint64 public numUsers;
 
-    constructor() public {
-        deployer = msg.sender;
-    }
-
     // @dev: function to intiate a new auction
     // Warning: In case the auction is expected to raise more than
     // 2^96 units of the tokenIn, don't start the auction, as
@@ -140,7 +136,8 @@ contract FairSale {
         uint96 _minBuyAmount,
         uint256 _minimumBiddingAmountPerOrder,
         uint256 _minFundingThreshold,
-        bool _isAtomicClosureAllowed
+        bool _isAtomicClosureAllowed,
+        address _owner
     ) internal {
         // withdraws sellAmount
         initialized = true;
@@ -165,7 +162,7 @@ contract FairSale {
         );
         sellOrders.initializeEmptyList();
         uint64 userId = getUserId(msg.sender);
-
+        owner = _owner;
         tokenOut = _tokenOut;
         tokenIn = _tokenIn;
         orderCancellationEndDate = _orderCancellationEndDate;
@@ -536,7 +533,7 @@ contract FairSale {
         sendOutTokens(sumTokenOutAmount, sumTokenInAmount, userId); //[3]
     }
 
-    function init(bytes calldata _data) public notInitialized onlyDeployer {
+    function init(bytes calldata _data) public notInitialized {
         (
             IERC20 _tokenIn,
             IERC20 _tokenOut,
@@ -546,7 +543,8 @@ contract FairSale {
             uint96 _minBidAmountToReceive,
             uint256 _minimumBiddingAmountPerOrder,
             uint256 _minSellThreshold,
-            bool _isAtomicClosureAllowed
+            bool _isAtomicClosureAllowed,
+            address _owner
         ) = abi.decode(
                 _data,
                 (
@@ -558,7 +556,8 @@ contract FairSale {
                     uint96,
                     uint256,
                     uint256,
-                    bool
+                    bool,
+                    address
                 )
             );
 
@@ -571,7 +570,8 @@ contract FairSale {
             _minBidAmountToReceive,
             _minimumBiddingAmountPerOrder,
             _minSellThreshold,
-            _isAtomicClosureAllowed
+            _isAtomicClosureAllowed,
+            _owner
         );
     }
 

--- a/contracts/templates/FairSaleTemplate.sol
+++ b/contracts/templates/FairSaleTemplate.sol
@@ -81,7 +81,8 @@ contract FairSaleTemplate is AquaTemplate {
             _minBuyAmount,
             _minimumBiddingAmountPerOrder,
             _minRaise,
-            isAtomicClosureAllowed
+            isAtomicClosureAllowed,
+            tokenSupplier
         );
 
         emit TemplateInitialized(

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -10,6 +10,7 @@ export interface InitiateAuctionInput {
     minimumBiddingAmountPerOrder: BigNumberish;
     minFundingThreshold: BigNumberish;
     isAtomicClosureAllowed: boolean;
+    owner: string;
 }
 
 export const contractConstructorArgs = <T extends ContractFactory>(

--- a/test/contract/FairSaleTemplate.spec.ts
+++ b/test/contract/FairSaleTemplate.spec.ts
@@ -199,5 +199,8 @@ describe("FairSaleTemplate", async () => {
         await expect(
             fairSaleTemplate.connect(user_2).createSale()
         ).to.be.revertedWith("FairSaleTemplate: FORBIDDEN");
+
+        await tokenB.approve(saleLauncher.address, expandTo18Decimals(3000));
+        await expect(fairSaleTemplate.createSale()).not.to.be.reverted;
     });
 });

--- a/test/contract/utilities.ts
+++ b/test/contract/utilities.ts
@@ -58,7 +58,8 @@ export const encodeFairSaleInitData = (
     minBidAmountToReceive: BigNumberish,
     minimumBiddingAmountPerOrder: BigNumberish,
     minSellThreshold: BigNumberish,
-    isAtomicClosureAllowed: boolean
+    isAtomicClosureAllowed: boolean,
+    owner: string
 ) => {
     return ethers.utils.defaultAbiCoder.encode(
         [
@@ -71,6 +72,7 @@ export const encodeFairSaleInitData = (
             "uint256",
             "uint256",
             "bool",
+            "address",
         ],
         [
             tokenIn,
@@ -82,6 +84,7 @@ export const encodeFairSaleInitData = (
             minimumBiddingAmountPerOrder,
             minSellThreshold,
             isAtomicClosureAllowed,
+            owner,
         ]
     );
 };


### PR DESCRIPTION
## Description

Owner of `FairSale` is now set in `init` instead of `constructor`.

## Motivation and Context

Currently `FairSale` sets owner of the contract in the `constructor` call which is always `0x0` when contract is cloned by `SaleLauncher`. Then, `init` could be initiated only by owner, so in practice `FairSale` could be never created.

List of changes:
- `onlyDeployer` => `onlyOwner` to be consistent wtih `FixedPriceSale`,
- `onlyOwner` modifier has been removed from `init`
- owner is now set in `init`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.